### PR TITLE
Fix bug in access_token.create_request function

### DIFF
--- a/lib/access_token.lua
+++ b/lib/access_token.lua
@@ -100,14 +100,15 @@ local new_request = require('oauth2c.request')
 --- create_request
 --- @param uri string @ token endpoint URI
 --- @param code string @ The authorization code received from the authorization server.
---- @param redirect_uri string @ REQUIRED, if the "redirect_uri" parameter was included in the authorization request as described in Section 4.1.1, and their values MUST be identical.
+--- @param redirect_uri string? @ OPTIONAL, if the "redirect_uri" parameter was included in the authorization request as described in Section 4.1.1, and their values MUST be identical.
 --- @param client_id string @ REQUIRED, if the client is not authenticating with the authorization server as described in Section 3.2.1.
 --- @param client_secret string @ REQUIRED, if the client is not authenticating with the authorization server as described in Section 3.2.1.
 --- @return oauth2c.access_token.request req
 local function create_request(uri, code, redirect_uri, client_id, client_secret)
     assert(is_str(uri), 'uri must be string')
     assert(is_str(code), 'code must be string')
-    assert(is_str(redirect_uri), 'redirect_uri must be string')
+    assert(redirect_uri == nil or is_str(redirect_uri),
+           'redirect_uri must be string')
     assert(is_str(client_id), 'client_id must be string')
     assert(is_str(client_secret), 'client_secret must be string')
 

--- a/test/oauth2c_test.lua
+++ b/test/oauth2c_test.lua
@@ -198,6 +198,25 @@ function testcase.create_authorization_request()
         },
     })
 
+    -- test that create authorization request without redirect_uri
+    o = oauth2c({
+        client_id = 'my_client_id',
+        client_secret = 'my_client_secret',
+        authz_uri = 'https://example.com/oauth2/authorize',
+        token_uri = 'https://example.com/oauth2/token',
+    })
+    req = o:create_authorization_request()
+    assert.re_match(req, '^oauth2c.request: ')
+    assert.contains(req, {
+        uri = 'https://example.com/oauth2/authorize',
+        state = req.state,
+        params = {
+            client_id = 'my_client_id',
+            response_type = 'code',
+            state = req.state,
+        },
+    })
+
     -- test that create authorization request with scope
     req = o:create_authorization_request('read write')
     assert.contains(req, {
@@ -206,7 +225,6 @@ function testcase.create_authorization_request()
         params = {
             client_id = 'my_client_id',
             response_type = 'code',
-            redirect_uri = 'http://example.com/authz/',
             state = req.state,
             scope = 'read write',
         },


### PR DESCRIPTION
the redirect_uri argument should be an optional argument.